### PR TITLE
🐛 fixed FirstTranslation resetting the initial query

### DIFF
--- a/src/GraphQL/Directives/FirstTranslationDirective.php
+++ b/src/GraphQL/Directives/FirstTranslationDirective.php
@@ -54,7 +54,16 @@ SDL;
                     throw new Exception('Multiple locales cannot be queried on a single returned instance! You have to only use "locale" filter on your "localeFilters" parameter.');
                 }
 
-                return $this->localeFilters($this->getModelClass(), $args)->first();
+                $locale = $args['locale'] ?? app()->getLocale();
+            
+                return $resolveInfo
+                    ->argumentSet
+                    ->enhanceBuilder(
+                        $this->getModelClass()::query()
+                            ->whereRelation('translation.locale', 'iso', '=', $locale),
+                        []
+                    )
+                    ->first();
             }
         );
     }


### PR DESCRIPTION
This fixes an issue encountered when using field directives such as `@eq` to evaluate conditions on results being ignored as a new model query was instanciated in `filterLocalesQuery`