### PR TITLE
📌 Pin bbs-lab/nova-cloudinary-field to 0.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   "require": {
     "php": ">=7.2",
     "ext-json": "*",
-    "bbs-lab/nova-cloudinary-field": "dev-master",
+    "bbs-lab/nova-cloudinary-field": "^0.3",
     "illuminate/contracts": "^6.2 || ^7.0 || ^8.0 || ^9.0",
     "illuminate/database": "^6.2 || ^7.0 || ^8.0 || ^9.0",
     "illuminate/support": "^6.2 || ^7.0 || ^8.0 || ^9.0"


### PR DESCRIPTION
bbs-lab/nova-cloudinary-field a été update et a besoin de PHP 8.1 au moins. Mon projet n'est pas encore passé sur PHP 8.0 et cette dépendance empêche la résolution et l'installation d'autre package 